### PR TITLE
Fix error with IOS 13 Version

### DIFF
--- a/Sources/SwiftDI/DSL/Never.swift
+++ b/Sources/SwiftDI/DSL/Never.swift
@@ -8,5 +8,7 @@
 import Foundation
 
 extension Never: DIPart {
-    
+    public var body: Never {
+        fatalError()
+    }
 }


### PR DESCRIPTION
Protocol 'DIPart' requires 'body' to be available in iOS 8.0.0 and newer